### PR TITLE
Support Globalize versions 4.0.0 -> 5.0.0.

### DIFF
--- a/authentication/refinerycms-authentication.gemspec
+++ b/authentication/refinerycms-authentication.gemspec
@@ -2,7 +2,7 @@
 require File.expand_path('../../core/lib/refinery/version', __FILE__)
 
 version = Refinery::Version.to_s
-rails_version = ['>= 4.0.2', '< 4.2']
+rails_version = ['>= 4.0.2', '< 5.0']
 
 Gem::Specification.new do |s|
   s.platform          = Gem::Platform::RUBY

--- a/core/refinerycms-core.gemspec
+++ b/core/refinerycms-core.gemspec
@@ -2,7 +2,7 @@
 require File.expand_path('../../core/lib/refinery/version', __FILE__)
 
 version = Refinery::Version.to_s
-rails_version = '~> 4.1.5'
+rails_version = ['>= 4.1.5', '< 5.0']
 
 Gem::Specification.new do |s|
   s.platform          = Gem::Platform::RUBY

--- a/pages/refinerycms-pages.gemspec
+++ b/pages/refinerycms-pages.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
   s.add_dependency 'friendly_id',                 '~> 5.0.1'
-  s.add_dependency 'globalize',                   '~> 4.0.0'
+  s.add_dependency 'globalize',                   ['>= 4.0.0', '< 5.1']
   s.add_dependency 'awesome_nested_set',          '~> 3.0.0'
   s.add_dependency 'seo_meta',                    '~> 2.0.0.rc.1'
   s.add_dependency 'refinerycms-core',            version


### PR DESCRIPTION
5.0.0 contains support for Rails 4.2
4.0.0 contains support for Rails 4.0 and 4.1